### PR TITLE
V2

### DIFF
--- a/src/components/navbar/NavBar.css
+++ b/src/components/navbar/NavBar.css
@@ -36,7 +36,63 @@ height: 58.48px;
     text-transform: uppercase;
     color: #18181A;
 }
+           
+#responsive-navbar-nav-control {
+    position: absolute;
+    top: 5em;
+    right: 1%;
+    margin-top: -45px;
+    width: 3em;
+    height: 45px;
+    z-index: 5;
+    transition: all 0.3s ease-in-out;
+  }
 
+  
 #responsive-navbar-toggle{
     justify-content: flex-end;
+   
+    
 }
+.offcanvas {
+    width: 100% !important; 
+    max-width: 100% !important;
+    
+    
+  }
+  
+  .offcanvas-header {
+    width: 100%;
+    padding: 1rem;
+    
+  }
+  
+
+.offcanvas-body {
+    display: flex; 
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem;
+    
+  }
+  
+  .offcanvas .nav {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  
+  }
+  
+  .offcanvas .nav-link {
+    padding: 2rem 50rem;
+    /* font-size: 1.2rem; */
+    text-align: center;
+    border-bottom: 0.8px solid grey;
+    
+    
+  }
+  
+  .offcanvas .nav-link + .nav-link {
+    margin-top: 1.5rem; 
+  }

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -1,7 +1,8 @@
-import { Nav, Navbar, Container, Row, Col, Collapse } from "react-bootstrap";
+import { Nav, Navbar,  NavDropdown, Offcanvas, Container, Row, Col, Collapse } from "react-bootstrap";
 import { LinkContainer } from "react-router-bootstrap";
 import NewLogo from "../../assets/NewLogo.svg";
 import "./NavBar.css";
+import { useState } from 'react';
 
 function Page({
   title,
@@ -20,6 +21,10 @@ function Page({
 }
 
 function NavBar() {
+  const [showOffcanvas, setShowOffcanvas] = useState(false);
+  const handleMenuToggle = () => {
+    setShowOffcanvas(!showOffcanvas);
+  };
   return (
     <Navbar className="nav" expand="lg">
       <Container id="navbar-container">
@@ -49,9 +54,48 @@ function NavBar() {
           <Navbar.Toggle
             aria-controls="responsive-navbar-nav"
             id="responsive-navbar-nav-control"
+            onClick={handleMenuToggle}
+            
           />
-          <Navbar.Collapse id="responsive-navbar-toggle">
+           {!showOffcanvas && (
+          <Navbar.Collapse id="responsive-navbar-nav" >
+         <Nav className="links-ms-auto">
+   
+              <Page
+              title={"Take Action"}
+              links={"/takeaction"}
+              className={"inner-text"}
+              ></Page>
+              <Page
+              title={"About Us"}
+              links={"/aboutus"}
+              className={"inner-text"}
+              ></Page>
+              <Page
+              title={"Contact"}
+              links={"/contact"}
+              className={"inner-text"}
+              ></Page>
+              <Page
+              title={"Testimonial"}
+              links={"/testimonials"}
+              className={"inner-text"}
+              ></Page>
+  
+          </Nav>
+         </Navbar.Collapse>
+         )}
+         <Offcanvas placement="end" show={showOffcanvas} onHide={() => setShowOffcanvas(false)} className={showOffcanvas ? "show" : "show"} >
+
+           <Offcanvas.Header closeButton>
+              <Offcanvas.Title> <img className="offcanvas-logo" src={NewLogo} alt="Logo" /></Offcanvas.Title>
+            </Offcanvas.Header>
+
+     
+          <Offcanvas.Body >
+      
             <Nav className="links-ms-auto">
+   
               <Page
                 title={"Take Action"}
                 links={"/takeaction"}
@@ -72,8 +116,11 @@ function NavBar() {
                 links={"/testimonials"}
                 className={"inner-text"}
               ></Page>
+             
             </Nav>
-          </Navbar.Collapse>
+            </Offcanvas.Body>
+            </Offcanvas>
+         
         </Col>
       </Container>
     </Navbar>


### PR DESCRIPTION
Changes: 
1. Add hamburger menu

Descriptions: 
1. When the screen size is smaller than 991px, a hamburger menu will appear
2. This will cause the horizontal menu bar to disappear. 
3. Clicking on the hamburger menu icon will reveal a full-screen menu.

<img width="633" alt="Screenshot 2023-07-24 at 10 07 57 PM" src="https://github.com/1thing-org/1thing.org/assets/81730540/f8b7861f-b82d-4a71-b39f-11e2aaf3b43a">

<img width="869" alt="Screenshot 2023-07-24 at 10 23 00 PM" src="https://github.com/1thing-org/1thing.org/assets/81730540/6db6a9b5-3785-4c5c-8fce-6b8d51d70d88">
