### PR TITLE
Tiny fix: Make Link open in a new tab

### DIFF
--- a/src/components/home/Chart/ChartView.js
+++ b/src/components/home/Chart/ChartView.js
@@ -179,6 +179,7 @@ const ChartView = () => {
             <Button
               className="chart-button"
               href="https://hatecrimetracker.1thing.org/"
+              target="_blank"
             >
               <div className="chart-button-text">View Project</div>
             </Button>


### PR DESCRIPTION
<img width="978" alt="new tab" src="https://github.com/1thing-org/1thing.org/assets/121676539/0922cc25-7af1-455b-8e0d-76b497c79322">

To open a link in a new tab, just include the **target="_blank"** attribute. 
Can use this for any link you wish to open in this manner.