### PR TITLE
Hide parameters in testimonials details url.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,39 +7,38 @@ import AboutUs from "./components/about/AboutUs";
 import Contact from "./components/contact/Contact";
 import ProjectTogether from "components/projects/projectTogether/ProjectTogether";
 import VictimSupportFund from "components/projects/victimSupportFund/VictimSupportFund";
-
 import InterviewPage from "./components/testimonials/VolunteerSection/InterviewPage";
 import VolunteerSection from "./components/testimonials/VolunteerSection/VolunteerSection";
+import { InterviewProvider } from "components/testimonials/VolunteerSection/InterviewContext";
 
 function App() {
   return (
-    <div className="App">
-      <Router>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/takeaction" element={<TakeAction />} />
+    <InterviewProvider>
+      <div className="App">
+        <Router>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/takeaction" element={<TakeAction />} />
 
-          <Route path="/testimonials" element={<Testimonials />} />
+            <Route path="/testimonials" element={<Testimonials />} />
 
-          <Route path="/volunteers" element={<VolunteerSection />} />
-          <Route
-            path="/interviews/:name/:interview/:pic/:quote"
-            element={<InterviewPage />}
-          />
+            <Route path="/volunteers" element={<VolunteerSection />} />
+            <Route path="/interviews/:name/" element={<InterviewPage />} />
 
-          <Route path="/aboutus" element={<AboutUs />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route
-            path="/projects/project-together"
-            element={<ProjectTogether />}
-          />
-          <Route
-            path="/projects/victim-support-fund"
-            element={<VictimSupportFund />}
-          />
-        </Routes>
-      </Router>
-    </div>
+            <Route path="/aboutus" element={<AboutUs />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route
+              path="/projects/project-together"
+              element={<ProjectTogether />}
+            />
+            <Route
+              path="/projects/victim-support-fund"
+              element={<VictimSupportFund />}
+            />
+          </Routes>
+        </Router>
+      </div>
+    </InterviewProvider>
   );
 }
 

--- a/src/components/testimonials/VolunteerSection/InterviewContext.jsx
+++ b/src/components/testimonials/VolunteerSection/InterviewContext.jsx
@@ -1,0 +1,12 @@
+import React, { createContext, useState } from "react";
+
+export const InterviewContext = createContext();
+export const InterviewProvider = ({ children }) => {
+  const [interviewData, setInterviewData] = useState({});
+
+  return (
+    <InterviewContext.Provider value={{ interviewData, setInterviewData }}>
+      {children}
+    </InterviewContext.Provider>
+  );
+};

--- a/src/components/testimonials/VolunteerSection/InterviewPage.tsx
+++ b/src/components/testimonials/VolunteerSection/InterviewPage.tsx
@@ -1,21 +1,16 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Col, Container, Row } from "react-bootstrap";
-import { useParams } from "react-router-dom";
-import Footer from "../../../components/footer/Footer";
-import NavBar from "../../../components/navbar/NavBar";
+import Footer from "../../footer/Footer";
+import NavBar from "../../navbar/NavBar";
+import { InterviewContext } from "./InterviewContext";
 import "./InterviewPage.css";
 
 function InterviewPage() {
-  const { name, pic, interview, quote } = useParams<{
-    name?: string;
-    quote?: string;
-    pic?: string;
-    interview?: string;
-  }>();
-  const paragraphs = interview
-    ? decodeURIComponent(interview).split("\n\n")
-    : [];
-
+  const { interviewData } = useContext(InterviewContext);
+  const name = interviewData.name;
+  const pic = interviewData.pic;
+  const interview = interviewData.interview;
+  const quote = interviewData.quote;
   if (!name || !pic || !interview || !quote) {
     // Handle the case when name or quote is undefined
     return <div>Invalid URL parameters.</div>;
@@ -44,17 +39,15 @@ function InterviewPage() {
           <Row></Row>
           <Row>
             <Col>
-              {paragraphs.map((para, index) => (
-                <p className="interview-paragraph" key={index}>
-                  {para}
-                </p>
-              ))}
-              <p className="interview-paragraph interview-name-bottom">{name}</p>
+              <p className="interview-paragraph">{interview}</p>
+              <p className="interview-paragraph interview-name-bottom">
+                {name}
+              </p>
             </Col>
           </Row>
         </Container>
       </Container>
-
+      
       <Footer />
     </div>
   );

--- a/src/components/testimonials/VolunteerSection/Volunteer.tsx
+++ b/src/components/testimonials/VolunteerSection/Volunteer.tsx
@@ -1,4 +1,7 @@
+import React, { useContext } from "react";
+import { useNavigate } from "react-router-dom";
 import Card from "react-bootstrap/Card";
+import { InterviewContext } from "./InterviewContext";
 import "./VolunteerSection.css";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 
@@ -10,17 +13,25 @@ type Props = {
 };
 
 function Volunteer(props: Props) {
+  const { setInterviewData } = useContext(InterviewContext);
+  const navigate = useNavigate();
+
+  const handleNavigate = () => {
+    setInterviewData({
+      name: props.name,
+      interview: props.interview,
+      pic: props.pic,
+      quote: props.quote,
+    });
+    navigate(`/interviews/${props.name}`);
+  };
+
   return (
     <Card id="volunteer">
       <Card.Img id="volunteer-profile-pic" src={props.pic} alt="Profile" />
       <Card.Text id="volunteer-name">{props.name}</Card.Text>
       <Card.Text id="volunteer-quote">{props.quote}</Card.Text>
-      <Card.Link
-        href={`/interviews/${props.name}/${encodeURIComponent(
-          props.interview
-        )}/${encodeURIComponent(props.pic)}/${encodeURIComponent(props.quote)}`}
-        id="volunteer-interview"
-      >
+      <Card.Link onClick={handleNavigate} id="volunteer-interview">
         Read More
       </Card.Link>
     </Card>

--- a/src/components/testimonials/VolunteerSection/VolunteerSection.tsx
+++ b/src/components/testimonials/VolunteerSection/VolunteerSection.tsx
@@ -42,22 +42,26 @@ function VolunteerSection(){
   }, []);
 
   const renderVolunteers = () => (
-    <Carousel showThumbs={false} showStatus={false} dynamicHeight={false} useKeyboardArrows={true}>
-       
-        {volunteerData.map((volunteer, index) => (       
-            <div key={index}>
-                <Volunteer 
-                    name={volunteer.name} 
-                    quote={volunteer.quote} 
-                    pic={volunteer.pic} 
-                    interview={volunteer.interview}
-                />
-                   
-            </div>
-        ))}
-    
+    <Carousel
+      showThumbs={false}
+      showStatus={false}
+      dynamicHeight={false}
+      useKeyboardArrows={true}
+    >
+      {volunteerData.map((volunteer, index) => (
+        <div key={index}>
+          <Volunteer
+            name={volunteer.name}
+            quote={volunteer.quote}
+            pic={volunteer.pic}
+            interview={volunteer.interview}
+          />
+
+        </div>
+      ))}
+      
     </Carousel>
-);
+  );
 
 return (
   <Container id="volunteer-section">


### PR DESCRIPTION
Hide parameters in testimonials details url.

In our https://test.1thing.org/ endpoint, when we click "Read more" button to read detailed interview for a specific person, we will encounter `400 ` error. I could not find the reason lead to this. One thing I guess may affect is the url contains too many data. An example of current url: 
```
https://test.1thing.org/interviews/Li%20M./In%20April%202021%2C%20my%20journey%20to%201%20Thing%20started%20with%20a%20basic%20presentation%20to%20document%20anti-Asian%20hate%20incidents%2C%20aiming%20to%20raise%20awareness%20among%20Google%20colleagues%20about%20the%20AAPI%20community's%20challenges.%20Unexpectedly%2C%20the%20presentation%20garnered%20attention%20within%20Google%2C%20leading%20others%20to%20contribute%20additional%20incidents%2C%20refine%20content%2C%20and%20share%20it%20widely.%20As%20a%20result%2C%20the%20presentation%20reached%20thousands%20of%20Googlers%20and%20was%20cited%20in%20numerous%20internal%20events%20and%20initiatives.%20%0A%0A%20I%20noticed%20that%20many%20AAPI%20community%20members%2C%20including%20myself%2C%20were%20upset%20about%20anti-Asian%20hate%20but%20seldom%20took%20action.%20Upon%20reflecting%20on%20my%20own%20inaction%2C%20I%20identified%20several%20excuses%2C%20such%20as%20feeling%20powerless%2C%20lacking%20time%20and%20resources%2C%20struggling%20to%20find%20suitable%20actions%2C%20being%20discouraged%20by%20the%20lack%20of%20results%2C%20and%20feeling%20isolated%20due%20to%20others'%20inactivity.%0A%0A%20The%20presentation%20experience%20shifted%20my%20perspective%2C%20motivating%20me%20to%20take%20manageable%20actions%20without%20fretting%20over%20immediate%20results%20and%20encouraging%20others%20to%20join%20me.%20I%20believed%20that%20if%20enough%20people%20became%20mobilized%2C%20real%20change%20would%20follow.%20This%20led%20me%20to%20establish%20the%20non-profit%20organization%2C%201%20Thing%20Against%20Racism.%20%0A%0A%201%20Thing's%20mission%20is%20to%20mobilize%20individuals%20and%20communities%20to%20take%20small%20actions%20against%20racism%20and%20hate%2C%20inspiring%20others%20to%20participate%20in%20the%20movement.%20By%20fostering%20a%20cycle%20of%20action%2C%20sharing%2C%20and%20inspiration%2C%20we%20aim%20to%20create%20a%20positive%20feedback%20loop%20that%20combines%20small%20efforts%20into%20a%20large%20social%20movement%20driving%20meaningful%20change.%20%0A%0A%20Using%20our%20volunteers'%20technological%20expertise%2C%201%20Thing%20developed%20tools%20to%20help%20others%20embrace%20the%201%20Thing%20concept.%20We%20transformed%20the%20anti-Asian%20hate%20incident%20presentation%20into%20the%20real-time%20tracking%20website%20hatecrimetracker.1thing.org.%20Upon%20analyzing%20incident%20data%2C%20we%20found%20many%20victims%20and%20families%20needed%20immediate%20assistance%2C%20so%20we%20established%20the%20anti-Asian%20hate%20victim%20support%20fund.%20Furthermore%2C%20volunteers%20are%20developing%20Together%2C%20a%20mobile%20app%20tailored%20for%20social%20and%20racial%20equality%20volunteers%2C%20enabling%20them%20to%20practice%20the%201%20Thing%20idea%20and%20achieve%20their%20objectives./%2Fstatic%2Fmedia%2FLi.df86ee8bd3e949da2dea.png/The%20presentation%20experience%20shifted%20my%20perspective%2C%20motivating%20me%20to%20take%20manageable%20actions%20without%20fretting%20over%20immediate%20results%20and%20encouraging%20others%20to%20join%20me.%20I%20believed%20that%20if%20enough%20people%20became%20mobilized%2C%20real%20change%20would%20follow.%20This%20led%20me%20to%20establish%20the%20non-profit%20organization%2C%201%20Thing%20Against%20Racism.
```
So, I use `Context` to hide data in url and now, the url looks like `http://localhost:3000/interviews/Li%20M.` Even if this could not solve the `400` bug, at least the url become cleaner.